### PR TITLE
Inflate the object in case of basic search

### DIFF
--- a/atlasclient/models.py
+++ b/atlasclient/models.py
@@ -832,6 +832,23 @@ class SearchBasic(base.QueryableModel):
                      'attributes': AttributeDef,
                      'fullTextResults': FullTextResult}
 
+    def inflate(self):
+        """Load the resource from the server, if not already loaded."""
+        if not self._is_inflated:
+            if self._is_inflating:
+                # catch infinite recursion when attempting to inflate
+                # an object that doesn't have enough data to inflate
+                msg = ("There is not enough data to inflate this object.  "
+                       "Need either an href: {} or a {}: {}")
+                msg = msg.format(self._href, self.primary_key, self._data.get(self.primary_key))
+                raise exceptions.ClientError(msg)
+
+            self._is_inflating = True
+            self.load(self._data)
+            self._is_inflated = True
+            self._is_inflating = False
+        return self
+
 
 class SearchDslCollection(base.QueryableModelCollection):
     def load(self, response):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -419,17 +419,19 @@ class TestDiscoveryREST():
             atlas_client.search_attribute.client.get.assert_called_with(s.url, params=params)
         for s in search_results:
             for e in s.entities:
-                    assert e.attributes['property1'] == {}
+                assert e.attributes['property1'] == {}
 
     def test_search_basic_get(self, mocker, atlas_client, search_attribute_response):
         mocker.patch.object(atlas_client.search_basic.client, 'get')
         search_attribute_response['queryType'] = 'BASIC'
-        atlas_client.search_basic.client.get.return_value =  search_attribute_response 
+        atlas_client.search_basic.client.get.return_value = search_attribute_response
         params = {'classification': 'class', 'excludedDeletedEntities': 'True', 'limit': '1'}
         search_results = atlas_client.search_basic(**params) 
         for s in search_results:
             assert s.queryType == 'BASIC'
             atlas_client.search_basic.client.get.assert_called_with(s.url, params=params)
+            for e in s.entities:
+                assert e.attributes['property1'] == {}
 
     def test_search_basic_post(self, mocker, atlas_client, search_attribute_response):
         mocker.patch.object(atlas_client.search_basic.client, 'get')


### PR DESCRIPTION
In case of basic search, we need to inflate the way we are doing in the attribute search. Otherwise it gives the error that not enough data to inflate. 