### PR TITLE
Add relational attributes for the entities detail

### DIFF
--- a/atlasclient/models.py
+++ b/atlasclient/models.py
@@ -48,7 +48,8 @@ class EntityCollection(base.DependentModelCollection):
 
 class Entity(base.DependentModel):
     collection_class = EntityCollection
-    fields = ('guid', 'status', 'displayText', 'classificationNames', 'typeName', 'attributes', 'createdBy', 'updatedBy', 'createTime', 'updateTime', 'version', 'relationshipAttributes', )
+    fields = ('guid', 'status', 'displayText', 'classificationNames', 'typeName', 'attributes', 'createdBy',
+              'updatedBy', 'createTime', 'updateTime', 'version', 'relationshipAttributes', )
 
 
 class EntityPostCollection(base.QueryableModelCollection):
@@ -831,23 +832,6 @@ class SearchBasic(base.QueryableModel):
     relationships = {'entities': Entity,
                      'attributes': AttributeDef,
                      'fullTextResults': FullTextResult}
-
-    def inflate(self):
-        """Load the resource from the server, if not already loaded."""
-        if not self._is_inflated:
-            if self._is_inflating:
-                # catch infinite recursion when attempting to inflate
-                # an object that doesn't have enough data to inflate
-                msg = ("There is not enough data to inflate this object.  "
-                       "Need either an href: {} or a {}: {}")
-                msg = msg.format(self._href, self.primary_key, self._data.get(self.primary_key))
-                raise exceptions.ClientError(msg)
-
-            self._is_inflating = True
-            self.load(self._data)
-            self._is_inflated = True
-            self._is_inflating = False
-        return self
 
 
 class SearchDslCollection(base.QueryableModelCollection):

--- a/atlasclient/models.py
+++ b/atlasclient/models.py
@@ -832,6 +832,23 @@ class SearchBasic(base.QueryableModel):
                      'attributes': AttributeDef,
                      'fullTextResults': FullTextResult}
 
+    def inflate(self):
+        """Load the resource from the server, if not already loaded."""
+        if not self._is_inflated:
+            if self._is_inflating:
+                # catch infinite recursion when attempting to inflate
+                # an object that doesn't have enough data to inflate
+                msg = ("There is not enough data to inflate this object.  "
+                       "Need either an href: {} or a {}: {}")
+                msg = msg.format(self._href, self.primary_key, self._data.get(self.primary_key))
+                raise exceptions.ClientError(msg)
+
+            self._is_inflating = True
+            self.load(self._data)
+            self._is_inflated = True
+            self._is_inflating = False
+        return self
+
 
 class SearchDslCollection(base.QueryableModelCollection):
     def load(self, response):

--- a/atlasclient/models.py
+++ b/atlasclient/models.py
@@ -48,7 +48,7 @@ class EntityCollection(base.DependentModelCollection):
 
 class Entity(base.DependentModel):
     collection_class = EntityCollection
-    fields = ('guid', 'status', 'displayText', 'classificationNames', 'typeName', 'attributes', 'createdBy', 'updatedBy', 'createTime', 'updateTime', 'version',)
+    fields = ('guid', 'status', 'displayText', 'classificationNames', 'typeName', 'attributes', 'createdBy', 'updatedBy', 'createTime', 'updateTime', 'version', 'relationshipAttributes', )
 
 
 class EntityPostCollection(base.QueryableModelCollection):


### PR DESCRIPTION
This adds the `relationshipAttributes` to the base Entity model. For now, every time we fetch the details of entities in bulk (`entity_bulk`), it has the option to fetch the related attributes already, but we were not doing that. As a result, we have to make extra queries to find details of each related object available in the entity. This will solve that problem, and all the related objects will be available in case of `entity_bulk`  and in places where possible. 